### PR TITLE
Clarified disclosure checkbox.

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/css/bootstrap.min.css" integrity="sha512-P5MgMn1jBN01asBgU0z60Qk4QxiXo86+wlFahKrsQf37c9cro517WzVSPPV1tDKzhku2iJ2FVgL67wG03SGnNA==" crossorigin="anonymous" />
 
-    <title>OSS Security Reviews: QuickStart Template!</title>
+    <title>OSS Security Reviews: QuickStart!</title>
     <style>
         body { font-family: 'Segoe UI', 'Helvetica Neue', sans-serif}
         textarea { font-family: 'Source Code Pro', Inconsolata, 'Consolas', monospace}
@@ -180,8 +180,9 @@
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" value="agreeDisclosure" id="disclosure" required>
                                     <label class="form-check-label" for="disclosure">
-                                        I agree that this review does not contain any significant, undisclosed, or
-                                        unpatched security vulnerabilities.</label>
+                                        I agree that this review does not contain details on any vulnerability that is undisclosed or not yet fixed..
+                                        For more information, view our <a href="https://github.com/ossf/security-reviews/wiki/Disclosure-Policy">disclosure policy</a>.
+                                    </label>
                                 </div>
                             </div>
                         </div>                                                      

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -180,7 +180,7 @@
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" value="agreeDisclosure" id="disclosure" required>
                                     <label class="form-check-label" for="disclosure">
-                                        I agree that this review does not contain details on any vulnerability that is undisclosed or not yet fixed..
+                                        I agree that this review does not contain details on any vulnerability that is undisclosed or is not yet fixed and is within 90 days of public disclosure.
                                         For more information, view our <a href="https://github.com/ossf/security-reviews/wiki/Disclosure-Policy">disclosure policy</a>.
                                     </label>
                                 </div>


### PR DESCRIPTION
This PR updates the checkbox in the QuickStart page to more accurately reflect the disclosure policy (and links to it).