### PR TITLE
Add SECURITY.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a collection of security reviews of open source softwar
 
 ## How do I submit a review?
 
-***Note: Do not disclose "new" or "unknown" vulnerabilities to this project or to this repository.***
+***Note: Do not disclose "new" or "unknown" vulnerabilities in other projects to this project or to this repository.***
 
 1. Choose an open source component.
 2. Complete the form on the [QuickStart](https://ossf.github.io/security-reviews/quickstart.html) page (this will generate your review as a markdown file).
@@ -127,6 +127,13 @@ Unless stated otherwise, documentation is released under the
 while code is released under the Apache license 2.0 (Apache-2.0).
 The documentation may link to other materials; those other materials retain
 their licenses.
+
+## Security / vulnerability reporting
+
+For information on how to
+report vulnerabilities in the software in this repository
+(e.g., our scripts), see
+[SECURITY.md](./SECURITY.md).
 
 ## More Information
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security
+
+**Do not disclose "new" or "unknown" vulnerabilities to this project or to this repository about other projects.**
+
+So, if you find a vulnerability (or evidence of one)
+in a specific project other than this one,
+and that vulnerability is not already well-known
+publicly, please report the vulnerability to *that* project.
+
+If you find a vulnerability (or evidence of one)
+in this specific project (e.g,. its scripts), please *do* report such
+vulnerabilities to us.
+
+We prefer that you use the [GitHub mechanism for privately reporting a vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability). Under the
+[main repository's security tab](https://github.com/coreinfrastructure/best-practices-badge/security), in the left sidebar, under "Reporting", click
+Advisories, then click "Report a vulnerability" to open the advisory form.


### PR DESCRIPTION
There are scripts here, and it's conceivable they could have a vulnerability. We *do* want *those* vulnerabilities reported to us. However, we don't want people to report new/unknown vulnerabilities in *other* projects here.

This adds a SECURITY.md file to hopefully make that clear, including how to report vulnerabilities in our scripts.

I also tweaked the README, both to point to the SECURITY.md file, and to make it clear what vulnerabilities we DO and DO NOT want reported.